### PR TITLE
Content-Type is no longer overwritten

### DIFF
--- a/HttpBrowser.php
+++ b/HttpBrowser.php
@@ -45,7 +45,7 @@ class HttpBrowser extends AbstractBrowser
         [$body, $extraHeaders] = $this->getBodyAndExtraHeaders($request);
 
         $response = $this->client->request($request->getMethod(), $request->getUri(), [
-            'headers' => array_merge($headers, $extraHeaders),
+            'headers' => $headers + $extraHeaders,
             'body' => $body,
             'max_redirects' => 0,
         ]);


### PR DESCRIPTION
Look in the $this->getBodyAndExtraHeaders method that by default return header:
```
['Content-Type' => 'application/x-www-form-urlencoded']
```
It is error because array_merge collapses arrays using a non-numeric key (non-strict comparison), and takes the value from the second array after collapsing.

This means that my 'Content-Type' will not be used.